### PR TITLE
Correct typo in "Continue" text

### DIFF
--- a/src/scenes/Game.tscn
+++ b/src/scenes/Game.tscn
@@ -595,7 +595,7 @@ margin_top = 44.0
 margin_right = 148.0
 margin_bottom = 68.0
 custom_fonts/font = ExtResource( 3 )
-text = "Conitune"
+text = "Continue"
 
 [node name="Bullets" type="YSort" parent="."]
 script = ExtResource( 1 )


### PR DESCRIPTION
Noticed a little typo on the game over screen i.e. `CONITUNE` instead of`CONTINUE` 🔎 

![xhess 2020-04-28 02_17_55](https://user-images.githubusercontent.com/121322/80470192-82710a00-88f6-11ea-92b0-b4e671e977b1.gif)

Fix attached for your consideration.

That was one of the most satisfying tower defense and/or chess-related games I've ever played. Well done!!! 