### PR TITLE
Add visualization for pieces attack before buy them

### DIFF
--- a/src/prefabs/GhostBullet.tscn
+++ b/src/prefabs/GhostBullet.tscn
@@ -1,0 +1,18 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://assets/FireZone.png" type="Texture" id=1]
+[ext_resource path="res://scripts/GhostBullet.gd" type="Script" id=2]
+
+[node name="GhostBullet" type="Node2D"]
+script = ExtResource( 2 )
+
+[node name="Sprite" type="Sprite" parent="."]
+texture = ExtResource( 1 )
+
+[node name="MoveTimer" type="Timer" parent="."]
+wait_time = 0.5
+
+[node name="ResetTimer" type="Timer" parent="."]
+wait_time = 2.0
+[connection signal="timeout" from="MoveTimer" to="." method="_on_MoveTimer_timeout"]
+[connection signal="timeout" from="ResetTimer" to="." method="_on_ResetTimer_timeout"]

--- a/src/project.godot
+++ b/src/project.godot
@@ -9,6 +9,11 @@
 config_version=4
 
 _global_script_classes=[ {
+"base": "Node2D",
+"class": "AttackCells",
+"language": "GDScript",
+"path": "res://scripts/AttackCells.gd"
+}, {
 "base": "Area2D",
 "class": "Bullet",
 "language": "GDScript",
@@ -23,6 +28,11 @@ _global_script_classes=[ {
 "class": "GameMap",
 "language": "GDScript",
 "path": "res://scripts/Map.gd"
+}, {
+"base": "Node2D",
+"class": "GhostBullet",
+"language": "GDScript",
+"path": "res://scripts/GhostBullet.gd"
 }, {
 "base": "Navigation2D",
 "class": "Navigator",
@@ -80,9 +90,11 @@ _global_script_classes=[ {
 "path": "res://scripts/WaveController.gd"
 } ]
 _global_script_class_icons={
+"AttackCells": "",
 "Bullet": "",
 "Bullets": "",
 "GameMap": "",
+"GhostBullet": "",
 "Navigator": "",
 "Spawner": "",
 "TileGhost": "",

--- a/src/scenes/BuyGhost.gd
+++ b/src/scenes/BuyGhost.gd
@@ -1,0 +1,11 @@
+extends TileGhost
+
+onready var attack_cells : Node2D = $AttackCells
+
+func show_ghost(texture : Texture = x_texture):
+	.show_ghost(texture)
+	attack_cells.draw_cells()
+
+func hide_ghost():
+	.hide_ghost()
+	attack_cells.clear_cells()

--- a/src/scenes/Game.tscn
+++ b/src/scenes/Game.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=59 format=2]
+[gd_scene load_steps=62 format=2]
 
 [ext_resource path="res://scripts/Bullets.gd" type="Script" id=1]
 [ext_resource path="res://assets/TurretIcons/TurretIcons1.png" type="Texture" id=2]
@@ -44,6 +44,8 @@
 [ext_resource path="res://audio/place.wav" type="AudioStream" id=42]
 [ext_resource path="res://audio/remove.wav" type="AudioStream" id=43]
 [ext_resource path="res://audio/button_press.wav" type="AudioStream" id=44]
+[ext_resource path="res://scripts/AttackCells.gd" type="Script" id=45]
+[ext_resource path="res://scenes/BuyGhost.gd" type="Script" id=46]
 
 [sub_resource type="Animation" id=1]
 resource_name = "Open"
@@ -142,6 +144,46 @@ animations = [ {
 } ]
 
 [sub_resource type="Animation" id=14]
+resource_name = "Jump"
+loop = true
+tracks/0/type = "value"
+tracks/0/path = NodePath(".:position")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/keys = {
+"times": PoolRealArray( 0, 0.499444, 0.992978 ),
+"transitions": PoolRealArray( 1, 1, 1 ),
+"update": 0,
+"values": [ Vector2( 0, 0 ), Vector2( 0, 2 ), Vector2( 0, 0 ) ]
+}
+tracks/1/type = "value"
+tracks/1/path = NodePath("..:self_modulate")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/keys = {
+"times": PoolRealArray( 0.00295529, 0.500922, 0.994456 ),
+"transitions": PoolRealArray( 1, 1, 1 ),
+"update": 0,
+"values": [ Color( 1, 1, 1, 0.72549 ), Color( 1, 1, 1, 0.0980392 ), Color( 1, 1, 1, 0.72549 ) ]
+}
+tracks/2/type = "value"
+tracks/2/path = NodePath("..:scale")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/keys = {
+"times": PoolRealArray( 0.00295529, 0.5024, 0.982634 ),
+"transitions": PoolRealArray( 1, 1, 1 ),
+"update": 0,
+"values": [ Vector2( 1, 1 ), Vector2( 0.8, 0.8 ), Vector2( 1, 1 ) ]
+}
+
+[sub_resource type="Animation" id=15]
 resource_name = "Jump"
 loop = true
 tracks/0/type = "value"
@@ -366,6 +408,7 @@ __meta__ = {
 [node name="AnimatedSprite" type="AnimatedSprite" parent="UI/StatsPanel/VBoxContainer/CoinsPanel"]
 scale = Vector2( 2, 2 )
 frames = SubResource( 6 )
+frame = 5
 speed_scale = 2.0
 playing = true
 centered = false
@@ -617,13 +660,12 @@ stream = ExtResource( 43 )
 volume_db = -20.0
 
 [node name="TileGhost" type="Node2D" parent="."]
-script = ExtResource( 40 )
-x_texture = ExtResource( 41 )
+visible = false
+script = ExtResource( 46 )
 
 [node name="Sprite" type="Sprite" parent="TileGhost"]
-visible = false
 self_modulate = Color( 1, 1, 1, 0.0980392 )
-position = Vector2( 0, -11 )
+position = Vector2( 8, 0 )
 texture = ExtResource( 41 )
 
 [node name="CostPanel" type="Node2D" parent="TileGhost/Sprite"]
@@ -646,7 +688,6 @@ __meta__ = {
 [node name="AnimatedSprite" type="AnimatedSprite" parent="TileGhost/Sprite/CostPanel/CostLabel"]
 position = Vector2( 4.74785, -12.489 )
 frames = SubResource( 13 )
-frame = 7
 speed_scale = 2.0
 playing = true
 centered = false
@@ -654,6 +695,50 @@ centered = false
 [node name="AnimationPlayer" type="AnimationPlayer" parent="TileGhost/Sprite/CostPanel"]
 autoplay = "Jump"
 anims/Jump = SubResource( 14 )
+
+[node name="AttackCells" type="Node2D" parent="TileGhost"]
+show_behind_parent = true
+position = Vector2( 8, -3 )
+script = ExtResource( 45 )
+
+[node name="SellGhost" type="Node2D" parent="."]
+visible = false
+script = ExtResource( 40 )
+x_texture = ExtResource( 41 )
+
+[node name="Sprite" type="Sprite" parent="SellGhost"]
+self_modulate = Color( 1, 1, 1, 0.0980392 )
+position = Vector2( 8, 0 )
+texture = ExtResource( 41 )
+offset = Vector2( 0, 8 )
+
+[node name="CostPanel" type="Node2D" parent="SellGhost/Sprite"]
+position = Vector2( 0, 1.99401 )
+
+[node name="CostLabel" type="Label" parent="SellGhost/Sprite/CostPanel"]
+margin_left = -12.5454
+margin_top = -21.6293
+margin_right = 13.4546
+margin_bottom = -9.62934
+custom_fonts/font = ExtResource( 35 )
+text = "10"
+align = 1
+valign = 1
+__meta__ = {
+"_edit_group_": true,
+"_edit_use_anchors_": false
+}
+
+[node name="AnimatedSprite" type="AnimatedSprite" parent="SellGhost/Sprite/CostPanel/CostLabel"]
+position = Vector2( 4.74785, -12.489 )
+frames = SubResource( 13 )
+speed_scale = 2.0
+playing = true
+centered = false
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="SellGhost/Sprite/CostPanel"]
+autoplay = "Jump"
+anims/Jump = SubResource( 15 )
 [connection signal="pressed" from="UI/TowerContainer/ButtonSell" to="UI/TowerContainer" method="_on_ButtonSell_pressed"]
 [connection signal="pressed" from="UI/MenuPanel/LevelPanel/HBox/LeftButton" to="UI/MenuPanel" method="prev_level"]
 [connection signal="pressed" from="UI/MenuPanel/LevelPanel/HBox/PlayButton" to="UI/MenuPanel" method="play"]

--- a/src/scripts/AttackCells.gd
+++ b/src/scripts/AttackCells.gd
@@ -1,0 +1,26 @@
+extends Node2D
+class_name AttackCells
+
+export var texture: Texture = preload("res://assets/FireZone.png")
+export(Resource) var tower_def = preload("res://resources/towers/Pawn.tres")
+
+var gameMap : GameMap
+var _bullet_scene: PackedScene = preload("res://prefabs/GhostBullet.tscn")
+
+func draw_cells():
+	for direction in tower_def.fireDirections:
+		var bullet := _bullet_scene.instance()
+		add_child(bullet)
+		bullet.move_direction = direction
+		bullet.position = Vector2(0, 11) + (direction * 16)
+		bullet.can_move = tower_def.recursively_fire
+
+
+func clear_cells():
+	for child in get_children():
+		remove_child(child)
+
+
+func update():
+	clear_cells()
+	draw_cells()

--- a/src/scripts/GhostBullet.gd
+++ b/src/scripts/GhostBullet.gd
@@ -1,0 +1,27 @@
+extends Node2D
+class_name GhostBullet
+
+var move_direction : Vector2
+var can_move : bool = false setget set_can_move
+
+var _initial_position : Vector2
+
+func set_can_move(moves):
+	can_move = moves
+	if can_move:
+		_initial_position = position
+		$MoveTimer.start()
+		$ResetTimer.start()
+
+func move():
+	var desired_position := position + 16 * move_direction
+	position = desired_position
+
+
+func _on_ResetTimer_timeout() -> void:
+	position = _initial_position
+	show()
+	$MoveTimer.start()
+
+func _on_MoveTimer_timeout() -> void:
+	move()

--- a/src/scripts/TileGhost.gd
+++ b/src/scripts/TileGhost.gd
@@ -3,24 +3,23 @@ class_name TileGhost
 
 onready var ghost : Sprite = $Sprite
 onready var coin_label : Label = $Sprite/CostPanel/CostLabel
+onready var cost_panel : Node2D = $Sprite/CostPanel
 
 export(Texture) var x_texture
 
 var gameMap : GameMap
-var offset = Vector2(8, -3)
 
-func _ready():
-	pass
-	
 func set_map(map : GameMap):
 	gameMap = map
 
-func show_ghost(pos : Vector2, cost : int, texture : Texture = x_texture):
-	var new_pos = pos + offset
-	ghost.visible = true
-	ghost.position = new_pos
-	ghost.texture = texture
+func set_cost(cost : int):
 	coin_label.text = String(cost)
-	
+	cost_panel.show()
+
+func show_ghost(texture : Texture = x_texture):
+	ghost.texture = texture
+	visible = true
+
 func hide_ghost():
-	ghost.visible = false
+	visible = false
+	cost_panel.hide()


### PR DESCRIPTION
Also refactor and optimize TileGhost procedures.

I think it would be good to show how the piece you are about to buy works. For instance, I don't quite know how each chess piece works, and having a visualization helps a lot.

It's also a good accessibility improvement as many players like me that don't know how each chess piece attacks, can join the game with lower attrition.

![kings-table-demo](https://user-images.githubusercontent.com/10171059/84554437-2e778480-acee-11ea-9ea7-6ff343b6bf87.gif)
